### PR TITLE
Add Safari note

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,5 @@
 
 A Rails app that allows users to have an audio conversation with an LLM using
 OpenAI's Speech to Text, Text to Speech APIs and gpt-4-turbo.
+
+Note: In Safari, you may need to set "Allow All Auto-Play" for localhost.


### PR DESCRIPTION
I believe auto-play is disabled by default in Safari, so I wasn't hearing the audio until I changed this setting.